### PR TITLE
Add compatibility with react-frame-component

### DIFF
--- a/src/components/Frame/Content.js
+++ b/src/components/Frame/Content.js
@@ -1,0 +1,15 @@
+import { Component } from 'https://unpkg.com/preact@latest?module';
+
+export default class Content extends Component {
+  componentDidMount() {
+    this.props.contentDidMount();
+  }
+
+  componentDidUpdate() {
+    this.props.contentDidUpdate();
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/src/components/Frame/Context.js
+++ b/src/components/Frame/Context.js
@@ -1,0 +1,17 @@
+import { createContext } from 'https://unpkg.com/preact@latest?module';
+
+let doc;
+let win;
+if (typeof document !== 'undefined') {
+  doc = document;
+}
+if (typeof window !== 'undefined') {
+  win = window;
+}
+
+export const FrameContext = createContext({ document: doc, window: win });
+
+export const {
+  Provider: FrameContextProvider,
+  Consumer: FrameContextConsumer
+} = FrameContext;

--- a/src/components/Frame/Frame.js
+++ b/src/components/Frame/Frame.js
@@ -1,0 +1,190 @@
+// This is a copy of react-frame-component@4.1.3 modified to use Preact
+// things explicitly since getting preact-compat from CDN doesn't work.
+import { html } from 'https://unpkg.com/htm/preact/index.module.js?module';
+import { Component, createElement, render } from 'https://unpkg.com/preact@latest?module';
+
+// createPortal copied from preact-compat (GH: preact@10.22.0 -> compat) because importing it from CDN doesn't work.
+function ContextProvider(props) {
+  this.getChildContext = () => props.context;
+  return props.children;
+}
+
+function Portal(props) {
+  const _this = this;
+  let container = props._container;
+
+  _this.componentWillUnmount = function () {
+    render(null, _this._temp);
+    _this._temp = null;
+    _this._container = null;
+  };
+
+  // When we change container we should clear our old container and
+  // indicate a new mount.
+  if (_this._container && _this._container !== container) {
+    _this.componentWillUnmount();
+  }
+
+  if (!_this._temp) {
+    _this._container = container;
+
+    // Create a fake DOM parent node that manages a subset of `container`'s children:
+    _this._temp = {
+      nodeType: 1,
+      parentNode: container,
+      childNodes: [],
+      appendChild(child) {
+        this.childNodes.push(child);
+        _this._container.appendChild(child);
+      },
+      insertBefore(child, before) {
+        this.childNodes.push(child);
+        _this._container.appendChild(child);
+      },
+      removeChild(child) {
+        this.childNodes.splice(this.childNodes.indexOf(child) >>> 1, 1);
+        _this._container.removeChild(child);
+      }
+    };
+  }
+
+  // Render our wrapping element into temp.
+  render(
+    createElement(ContextProvider, { context: _this.context }, props._vnode),
+    _this._temp
+  );
+}
+
+function createPortal(vnode, container) {
+  const el = createElement(Portal, { _vnode: vnode, _container: container });
+  el.containerInfo = container;
+  return el;
+}
+
+import { FrameContextProvider } from './Context.js';
+import Content from './Content.js';
+
+export default class Frame extends Component {
+  constructor(props, context) {
+    super(props, context);
+    this._isMounted = false;
+  }
+
+  get props() {
+    return this._props;
+  }
+
+  set props(value) {
+    const defaultProps = {
+      style: {},
+      head: null,
+      children: undefined,
+      mountTarget: undefined,
+      contentDidMount: () => {},
+      contentDidUpdate: () => {},
+      initialContent:
+        '<!DOCTYPE html><html><head></head><body><div class="frame-root"></div></body></html>'
+    };
+
+    this._props = {
+      ...defaultProps,
+      ...value,
+    };
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+
+    const doc = this.getDoc();
+    if (doc && doc.readyState === 'complete') {
+      this.forceUpdate();
+    } else {
+      this.node.addEventListener('load', this.handleLoad);
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+
+    this.node.removeEventListener('load', this.handleLoad);
+  }
+
+  getDoc() {
+    return this.node ? this.node.contentDocument : null;
+  }
+
+  getMountTarget() {
+    const doc = this.getDoc();
+    if (this.props.mountTarget) {
+      return doc.querySelector(this.props.mountTarget);
+    }
+    return doc.body.children[0];
+  }
+
+  handleLoad = () => {
+    this.forceUpdate();
+  };
+
+  renderFrameContents() {
+    if (!this._isMounted) {
+      return null;
+    }
+
+    const doc = this.getDoc();
+
+    if (!doc) {
+      return null;
+    }
+
+    const contentDidMount = this.props.contentDidMount;
+    const contentDidUpdate = this.props.contentDidUpdate;
+
+    const win = doc.defaultView || doc.parentView;
+
+    const contents = html`
+      <${Content}
+        contentDidMount=${contentDidMount}
+        contentDidUpdate=${contentDidUpdate}
+      >
+        <${FrameContextProvider} value=${{ document: doc, window: win }}>
+          <div className="frame-content">${this.props.children}</div>
+        </>
+      </>
+    `;
+
+    if (doc.body.children.length < 1) {
+      doc.open('text/html', 'replace');
+      doc.write(this.props.initialContent);
+      doc.close();
+    }
+
+    const mountTarget = this.getMountTarget();
+
+    return [
+      createPortal(this.props.head, this.getDoc().head),
+      createPortal(contents, mountTarget)
+    ];
+  }
+
+  render() {
+    const props = {
+      ...this.props,
+      children: undefined // The iframe isn't ready so we drop children from props here. #12, #17
+    };
+    delete props.head;
+    delete props.initialContent;
+    delete props.mountTarget;
+    delete props.contentDidMount;
+    delete props.contentDidUpdate;
+    return html`
+      <iframe
+        ...${props}
+        ref=${(node) => {
+          this.node = node;
+        }}
+      >
+        ${this.renderFrameContents()}
+      </iframe>
+    `
+  }
+}

--- a/src/components/WorkerSafeFrame.js
+++ b/src/components/WorkerSafeFrame.js
@@ -3,41 +3,71 @@ import Frame from './Frame/Frame.js';
 export default class WorkerSafeFrame extends Frame {
   _hasWrittenInitialContent = false;
 
-  getMountTarget() {
-    // Fall back to the body since initial content that would be written
-    // via document.write() won't be written in the worker.
-    return super.getMountTarget() ?? this.getDoc().body;
-  }
-
   renderFrameContents() {
     if (this._hasWrittenInitialContent) {
       return super.renderFrameContents();
     }
 
-    // Run the document.write() call, but because we're sending it to the main thread
-    // it's async so we wait until that completes before we call the super.
+    // Populating the initial content here prevents the base class from attempting
+    // to call document.write (which isn't implemented in undom's Document class).
     this._writeInitialContent();
   }
 
   async _writeInitialContent() {
-    if (!this._isMounted) {
-      return;
-    }
-
     const doc = this.getDoc();
     if (!doc) {
       return;
     }
 
-    if (doc.body.children.length < 1) {
-      await doc.write(this.props.initialContent); // async polyfill because we have to post to the main thread.
+    await new Promise((resolve) => {
+      const onHtmlParsed = ({ data }) => {
+        if (data.type !== 'htmlParsed') {
+          return;
+        }
 
-      // Stub document.write calls to prevent the base class getting stuck in
-      // a loop where it calls renderFrameContents and we end up here again.
-      doc.write = function() {};
-    }
+        removeEventListener('message', onHtmlParsed);
+
+        // TODO: extract this to a reusable utility and maybe DRY up with element creation in DomMutationHandler.
+        const convertObjectToElement = (o, d) => {
+          let e;
+          if (o.nodeType === 3) {
+            e = d.createTextNode(o.nodeValue);
+          }
+          else if (o.nodeType === 1) {
+            e = d.createElement(o.nodeName);
+
+            o.attributes.forEach(({ name, value }) => {
+              e.setAttribute(name, value);
+            });
+
+            o.childNodes.forEach((child) => {
+              e.appendChild(convertObjectToElement(child, d));
+            });
+          }
+
+          return e;
+        };
+
+        // Rebuild the document's contents from the parsed HTML.
+        doc.documentElement = convertObjectToElement(JSON.parse(data.tree), doc);
+
+        const childNodes = doc.documentElement.childNodes;
+        doc.head = childNodes.find((n) => n.nodeName === 'HEAD');
+        doc.body = childNodes.find((n) => n.nodeName === 'BODY');
+
+        resolve();
+      };
+
+      addEventListener('message', onHtmlParsed);
+      postMessage({
+        type: 'parseHtml',
+        text: this.props.initialContent,
+      });
+    });
 
     this._hasWrittenInitialContent = true;
-    this.renderFrameContents();
+
+    // Trigger a re-render to flush the real frame contents to the virtual DOM.
+    this.forceUpdate();
   }
 };

--- a/src/components/WorkerSafeFrame.js
+++ b/src/components/WorkerSafeFrame.js
@@ -1,9 +1,43 @@
 import Frame from './Frame/Frame.js';
 
 export default class WorkerSafeFrame extends Frame {
+  _hasWrittenInitialContent = false;
+
   getMountTarget() {
     // Fall back to the body since initial content that would be written
     // via document.write() won't be written in the worker.
     return super.getMountTarget() ?? this.getDoc().body;
+  }
+
+  renderFrameContents() {
+    if (this._hasWrittenInitialContent) {
+      return super.renderFrameContents();
+    }
+
+    // Run the document.write() call, but because we're sending it to the main thread
+    // it's async so we wait until that completes before we call the super.
+    this._writeInitialContent();
+  }
+
+  async _writeInitialContent() {
+    if (!this._isMounted) {
+      return;
+    }
+
+    const doc = this.getDoc();
+    if (!doc) {
+      return;
+    }
+
+    if (doc.body.children.length < 1) {
+      await doc.write(this.props.initialContent); // async polyfill because we have to post to the main thread.
+
+      // Stub document.write calls to prevent the base class getting stuck in
+      // a loop where it calls renderFrameContents and we end up here again.
+      doc.write = function() {};
+    }
+
+    this._hasWrittenInitialContent = true;
+    this.renderFrameContents();
   }
 };

--- a/src/components/WorkerSafeFrame.js
+++ b/src/components/WorkerSafeFrame.js
@@ -1,0 +1,9 @@
+import Frame from './Frame/Frame.js';
+
+export default class WorkerSafeFrame extends Frame {
+  getMountTarget() {
+    // Fall back to the body since initial content that would be written
+    // via document.write() won't be written in the worker.
+    return super.getMountTarget() ?? this.getDoc().body;
+  }
+};

--- a/src/components/WorkerSafeFrame.js
+++ b/src/components/WorkerSafeFrame.js
@@ -1,25 +1,63 @@
 import Frame from './Frame/Frame.js';
 
 export default class WorkerSafeFrame extends Frame {
-  _hasWrittenInitialContent = false;
+  _hasInsertedInitialContent = false;
 
+  // Override the base class's method to prevent it from calling document.write
+  // because it's not implemented in undom's Document class. Once we've inserted
+  // the content ourselves, we'll call through to the base class's implementation.
   renderFrameContents() {
-    if (this._hasWrittenInitialContent) {
+    if (this._hasInsertedInitialContent) {
       return super.renderFrameContents();
     }
 
-    // Populating the initial content here prevents the base class from attempting
-    // to call document.write (which isn't implemented in undom's Document class).
-    this._writeInitialContent();
+    this._insertInitialContent();
   }
 
-  async _writeInitialContent() {
+  async _insertInitialContent() {
     const doc = this.getDoc();
     if (!doc) {
       return;
     }
 
-    await new Promise((resolve) => {
+    const tree = await this._parse(this.props.initialContent);
+
+    // TODO: extract this to a reusable utility and maybe DRY up with element creation in DomMutationHandler.
+    const convertObjectToElement = (o, d) => {
+      let e;
+      if (o.nodeType === 3) {
+        e = d.createTextNode(o.nodeValue);
+      }
+      else if (o.nodeType === 1) {
+        e = d.createElement(o.nodeName);
+
+        o.attributes.forEach(({ name, value }) => {
+          e.setAttribute(name, value);
+        });
+
+        o.childNodes.forEach((child) => {
+          e.appendChild(convertObjectToElement(child, d));
+        });
+      }
+
+      return e;
+    };
+
+    // Rebuild the document's contents from the parsed HTML.
+    doc.documentElement = convertObjectToElement(tree, doc);
+
+    const childNodes = doc.documentElement.childNodes;
+    doc.head = childNodes.find((n) => n.nodeName === 'HEAD');
+    doc.body = childNodes.find((n) => n.nodeName === 'BODY');
+
+    this._hasInsertedInitialContent = true;
+
+    // Trigger a re-render to flush the real frame contents to the virtual DOM.
+    this.forceUpdate();
+  }
+
+  _parse(html) {
+    return new Promise((resolve) => {
       const onHtmlParsed = ({ data }) => {
         if (data.type !== 'htmlParsed') {
           return;
@@ -27,47 +65,14 @@ export default class WorkerSafeFrame extends Frame {
 
         removeEventListener('message', onHtmlParsed);
 
-        // TODO: extract this to a reusable utility and maybe DRY up with element creation in DomMutationHandler.
-        const convertObjectToElement = (o, d) => {
-          let e;
-          if (o.nodeType === 3) {
-            e = d.createTextNode(o.nodeValue);
-          }
-          else if (o.nodeType === 1) {
-            e = d.createElement(o.nodeName);
-
-            o.attributes.forEach(({ name, value }) => {
-              e.setAttribute(name, value);
-            });
-
-            o.childNodes.forEach((child) => {
-              e.appendChild(convertObjectToElement(child, d));
-            });
-          }
-
-          return e;
-        };
-
-        // Rebuild the document's contents from the parsed HTML.
-        doc.documentElement = convertObjectToElement(JSON.parse(data.tree), doc);
-
-        const childNodes = doc.documentElement.childNodes;
-        doc.head = childNodes.find((n) => n.nodeName === 'HEAD');
-        doc.body = childNodes.find((n) => n.nodeName === 'BODY');
-
-        resolve();
+        resolve(JSON.parse(data.tree));
       };
 
       addEventListener('message', onHtmlParsed);
       postMessage({
         type: 'parseHtml',
-        text: this.props.initialContent,
+        text: html,
       });
     });
-
-    this._hasWrittenInitialContent = true;
-
-    // Trigger a re-render to flush the real frame contents to the virtual DOM.
-    this.forceUpdate();
   }
 };

--- a/src/utils/dom/DomMutationCollector.js
+++ b/src/utils/dom/DomMutationCollector.js
@@ -6,11 +6,11 @@ export default class DomMutationCollector {
   }
 
   collectMutation(mutation) {
-    const isFirstMutationInBatch = !!this._pendingMutations.length;
+    const isFirstMutationInBatch = !this._pendingMutations.length;
   
     this._pendingMutations.push(mutation);
   
-    if (!isFirstMutationInBatch) {
+    if (isFirstMutationInBatch) {
       // Using setTimeout allows us to collect all mutations from
       // the currently-executing task before invoking the callback,
       // so we can emit mutations in batches instead of one by one.

--- a/src/utils/dom/DomMutationHandler.js
+++ b/src/utils/dom/DomMutationHandler.js
@@ -47,7 +47,7 @@ export default class DomMutationHandler {
       case 'BODY':
         // Worker renders unframed content into the virtual body. Returning the container node
         // instead allows the consuming app to specify where the worker's output is rendered.
-        node = vNode.ownerDocument ? this._getNode(vNode.ownerDocument).body : this._container;
+        node = vNode.ownerDocumentId ? this._nodes.get(vNode.ownerDocumentId).body : this._container;
         break;
 
       default:

--- a/src/utils/dom/DomMutationHandler.js
+++ b/src/utils/dom/DomMutationHandler.js
@@ -1,11 +1,11 @@
 const upperCaseFirstChar = (str) => str[0].toUpperCase() + str.slice(1);
 
 export default class DomMutationHandler {
-  constructor({ container, onNodeFirstSeen }) {
+  constructor({ container, nodes, onNodeFirstSeen }) {
     this._container = container;
+    this._nodes = nodes;
     this._onNodeFirstSeen = onNodeFirstSeen;
 
-    this._nodes = new Map();
     this._pendingMutations = [];
   }
 
@@ -54,7 +54,6 @@ export default class DomMutationHandler {
         node = this._createNode(vNode);
     }
 
-    this._nodes.set(vNode._id, node);
     node._id = vNode._id;
     this._onNodeFirstSeen(node);
 

--- a/src/utils/dom/DomMutationHandler.js
+++ b/src/utils/dom/DomMutationHandler.js
@@ -145,6 +145,7 @@ export default class DomMutationHandler {
 
     addedNodes?.forEach((node) => {
       if (this._isPreCreatedNode(node)) {
+        // TODO: do we need merge node into existing node (e.g. if frame initial content adds attributes to body)?
         return;
       }
 

--- a/src/utils/dom/DomMutationHandler.js
+++ b/src/utils/dom/DomMutationHandler.js
@@ -1,8 +1,9 @@
 const upperCaseFirstChar = (str) => str[0].toUpperCase() + str.slice(1);
 
 export default class DomMutationHandler {
-  constructor({ container }) {
+  constructor({ container, onNodeFirstSeen }) {
     this._container = container;
+    this._onNodeFirstSeen = onNodeFirstSeen;
 
     this._nodes = new Map();
     this._pendingMutations = [];
@@ -54,6 +55,8 @@ export default class DomMutationHandler {
     }
 
     this._nodes.set(vNode._id, node);
+    node._id = vNode._id;
+    this._onNodeFirstSeen(node);
 
     return node;
   }

--- a/src/utils/dom/DomMutationHandler.js
+++ b/src/utils/dom/DomMutationHandler.js
@@ -19,7 +19,7 @@ export default class DomMutationHandler {
       return null;
     }
 
-    let node = this._nodes.get(vNode);
+    let node = this._nodes.get(vNode._id);
 
     if (node) {
       return node;
@@ -36,18 +36,18 @@ export default class DomMutationHandler {
 
       case 'HTML':
         // Only happens for iframe content.
-        node = this._nodes.get(vNode.ownerDocumentId).documentElement;
+        node = this._getOwnerDocument(vNode).documentElement;
         break;
 
       case 'HEAD':
         // Only happens for iframe content.
-        node = this._nodes.get(vNode.ownerDocumentId).head;
+        node = this._getOwnerDocument(vNode).head;
         break;
 
       case 'BODY':
         // Worker renders unframed content into the virtual body. Returning the container node
         // instead allows the consuming app to specify where the worker's output is rendered.
-        node = vNode.ownerDocumentId ? this._nodes.get(vNode.ownerDocumentId).body : this._container;
+        node = vNode.ownerDocumentId ? this._getOwnerDocument(vNode).body : this._container;
         break;
 
       default:
@@ -61,13 +61,21 @@ export default class DomMutationHandler {
     return node;
   }
 
+  _getOwnerDocument(node) {
+    return node.ownerDocumentId ?
+      this._nodes.get(node.ownerDocumentId) :
+      document;
+  }
+
   _createNode(vNode) {
     let node;
+    const doc = this._getOwnerDocument(vNode);
+
     if (vNode.nodeType === 3) {
-      node = document.createTextNode(vNode.nodeValue);
+      node = doc.createTextNode(vNode.nodeValue);
     }
     else if (vNode.nodeType === 1) {
-      node = document.createElement(vNode.nodeName);
+      node = doc.createElement(vNode.nodeName);
   
       if (vNode.className) {
         node.className = vNode.className;

--- a/src/utils/dom/DomMutationMessagePoster.js
+++ b/src/utils/dom/DomMutationMessagePoster.js
@@ -1,4 +1,10 @@
+// List of props to avoid serialising because they introduce circular references.
 const NON_SERIALISABLE_PROPS = [
+  'contentDocument',
+  'document',
+  'documentElement',
+  'head',
+  'body',
   'children',
   'parentNode',
   '__handlers',
@@ -40,7 +46,7 @@ export default class DomMutationMessagePoster {
     }
   
     this._nodeCollection.add(node);
-  
+
     const serialisableNode = Object.keys(node).reduce((serialisableNode, propName) => {
       if (node.hasOwnProperty(propName) && NON_SERIALISABLE_PROPS.indexOf(propName) === -1) {
         serialisableNode[propName] = node[propName];
@@ -48,6 +54,10 @@ export default class DomMutationMessagePoster {
   
       return serialisableNode;
     }, {});
+
+    if (node.ownerDocument) {
+      serialisableNode.ownerDocument = node.ownerDocument._id;
+    }
   
     if (serialisableNode.childNodes?.length) {
       serialisableNode.childNodes = this._getSerialisableCopy(serialisableNode.childNodes);

--- a/src/utils/dom/DomMutationMessagePoster.js
+++ b/src/utils/dom/DomMutationMessagePoster.js
@@ -7,6 +7,8 @@ const NON_SERIALISABLE_PROPS = [
   'body',
   'children',
   'parentNode',
+  'ownerDocument',
+  'ownerFrame',
   '__handlers',
   '_component',
   '_componentConstructor',
@@ -56,13 +58,13 @@ export default class DomMutationMessagePoster {
     }, {});
 
     [
-      'ownerFrame',
       'ownerDocument',
+      'ownerFrame',
     ].forEach((propName) => {
       const owner = node[propName];
 
       if (owner) {
-        serialisableNode[propName] = owner._id;
+        serialisableNode[`${propName}Id`] = owner._id;
       }
     });
   

--- a/src/utils/dom/DomMutationMessagePoster.js
+++ b/src/utils/dom/DomMutationMessagePoster.js
@@ -55,9 +55,16 @@ export default class DomMutationMessagePoster {
       return serialisableNode;
     }, {});
 
-    if (node.ownerDocument) {
-      serialisableNode.ownerDocument = node.ownerDocument._id;
-    }
+    [
+      'ownerFrame',
+      'ownerDocument',
+    ].forEach((propName) => {
+      const owner = node[propName];
+
+      if (owner) {
+        serialisableNode[propName] = owner._id;
+      }
+    });
   
     if (serialisableNode.childNodes?.length) {
       serialisableNode.childNodes = this._getSerialisableCopy(serialisableNode.childNodes);

--- a/src/utils/dom/EventForwarder.js
+++ b/src/utils/dom/EventForwarder.js
@@ -1,15 +1,19 @@
 export default class EventForwarder {
-  constructor(onEvent) {
-    this._touchData = null;
+  constructor(target, onEvent) {
+    this._target = target;
     this._onEvent = onEvent;
+
+    this._touchData = null;
 
     this._initEventForwarding();
   }
 
   _initEventForwarding() {
+    const target = this._target;
+
     let supportsPassive = false;
     try {
-      addEventListener('test', null, {
+      target.addEventListener('test', null, {
         get passive() { supportsPassive = true; }
       });
     } catch (e) {}
@@ -31,16 +35,16 @@ export default class EventForwarder {
       'unload', // triggers deprecation warning
     ];
 
-    // Loop over all "on*" event names on Window and set up a proxy handler for each.
-    for (let propName in window) {
+    // Loop over all "on*" event names on target object and set up a proxy handler for each.
+    for (let propName in target) {
       const eventName = propName.substring(2);
       if (
         propName.substring(0,2) === 'on' &&
         propName === propName.toLowerCase() &&
         eventsToIgnore.indexOf(eventName) < 0 &&
-        (window[propName] === null || typeof window[propName] === 'function')
+        (target[propName] === null || typeof target[propName] === 'function')
       ) {
-        addEventListener(eventName, (e) => this._forwardEvent(e), eventOptions);
+        target.addEventListener(eventName, (e) => this._forwardEvent(e), eventOptions);
       }
     }
   }

--- a/src/utils/dom/ForwardedEventHandler.js
+++ b/src/utils/dom/ForwardedEventHandler.js
@@ -4,9 +4,17 @@ export default class ForwardedEventHandler {
   }
 
   handleEvent(event) {
-    const target = this._nodeCollection.get(event.target);
+    let target = this._nodeCollection.get(event.target);
 
-    target?.dispatchEvent({
+    while (!target?.dispatchEvent) {
+      target = target?.parentNode;
+
+      if (!target) {
+        return;
+      }
+    }
+
+    target.dispatchEvent({
       ...event,
       target,
       bubbles: true,

--- a/src/utils/dom/NodeCollection.js
+++ b/src/utils/dom/NodeCollection.js
@@ -9,9 +9,11 @@ export default class NodeCollection {
       return;
     }
 
-    const id = String(++this._nodesCount);
-    node._id = id;
-    this._nodes.set(id, node);
+    this._add(node);
+
+    if (node.nodeName === 'IFRAME') {
+      this._add(node.contentDocument);
+    }
   }
 
   get(node) {
@@ -24,5 +26,11 @@ export default class NodeCollection {
     }
 
     return id ? this._nodes.get(id) : null;
+  }
+
+  _add(node) {
+    const id = String(++this._nodesCount);
+    node._id = id;
+    this._nodes.set(id, node);
   }
 }

--- a/src/utils/dom/NodeSerialiser.js
+++ b/src/utils/dom/NodeSerialiser.js
@@ -1,0 +1,44 @@
+export default class NodeSerialiser {
+  static serialiseNode(node) {
+    return JSON.stringify(
+      this._convertElementToObject(node)
+    );
+  }
+
+  static deserialiseNode(str, doc) {
+    return this._convertObjectToElement(
+      JSON.parse(str),
+      doc
+    );
+  }
+
+  static _convertElementToObject(e) {
+    return {
+      nodeName: e.nodeName,
+      nodeType: e.nodeType,
+      nodeValue: e.nodeValue,
+      attributes: [...e.attributes].map(({ name, value }) => ({ name, value })),
+      childNodes: [...e.childNodes].map(NodeSerialiser._convertElementToObject),
+    };
+  }
+
+  static _convertObjectToElement(o, d) {
+    let e;
+    if (o.nodeType === 3) {
+      e = d.createTextNode(o.nodeValue);
+    }
+    else if (o.nodeType === 1) {
+      e = d.createElement(o.nodeName);
+
+      o.attributes.forEach(({ name, value }) => {
+        e.setAttribute(name, value);
+      });
+
+      o.childNodes.forEach((child) => {
+        e.appendChild(NodeSerialiser._convertObjectToElement(child, d));
+      });
+    }
+
+    return e;
+  }
+}

--- a/src/utils/dom/createVirtualDom.js
+++ b/src/utils/dom/createVirtualDom.js
@@ -1,7 +1,10 @@
 import undom from 'https://unpkg.com/undom@latest?module';
+import shimIFrameCreation from './shimIFrameCreation.js';
 
 const createVirtualDom = (documentParent = globalThis) => {
   documentParent.document = undom();
+
+  shimIFrameCreation();
 };
 
 export default createVirtualDom;

--- a/src/utils/dom/shimIFrameCreation.js
+++ b/src/utils/dom/shimIFrameCreation.js
@@ -40,24 +40,24 @@ const shimIFrameCreation = () => {
 
     // react-frame-component uses these methods to inject the initial
     // content into the frame's document, so we need to provide them.
-    doc.open = () => {};
-    doc.close = () => {};
+    doc.open = function() {};
+    doc.close = function() {};
 
-    doc.write = async () => {
+    doc.write = async function(content) {
       return new Promise((resolve) => {
         const onCompleted = ({ data }) => {
           if (data.type !== 'documentWritten') {
             return;
           }
 
-          console.log('documentWritten');
           removeEventListener('message', onCompleted);
           resolve();
         };
 
         addEventListener('message', onCompleted);
-        postMessage('writeDocument', {
-          content: this.props.initialContent,
+        postMessage({
+          type: 'writeDocument',
+          content,
           documentId: this._id,
         });
       });

--- a/src/utils/dom/shimIFrameCreation.js
+++ b/src/utils/dom/shimIFrameCreation.js
@@ -7,6 +7,8 @@ const shimIFrameCreation = () => {
 
     // Initialise a new virtual document for the frame.
     const doc = new document.Document();
+
+    // Copy required properties (not on prototype) from top-level document.
     [
       'createElement',
       'createElementNS',
@@ -21,6 +23,8 @@ const shimIFrameCreation = () => {
       doc[propName] = document[propName];
     });
 
+    // Wrap node creation methods to associate the created node with the document.
+    // This allows the main thread to find the correct document for the node.
     [
       'createElement',
       'createElementNS',
@@ -40,11 +44,14 @@ const shimIFrameCreation = () => {
     doc.write = () => {}; // TODO: probably need to write into the real DOM so frame gets its initial content
     doc.close = () => {};
 
+    doc.ownerFrame = el;
+
     // Wrapping this in a setTimeout allows the iframe creation to have been
     // passed to the main thread before we start manipulating it. Otherwise,
     // we have no way of associating the document with its frame in the main
     // thread.
     setTimeout(() => {
+
       const docElement = doc.createElement('html');
       doc.documentElement = docElement;
       doc.appendChild(docElement);

--- a/src/utils/dom/shimIFrameCreation.js
+++ b/src/utils/dom/shimIFrameCreation.js
@@ -1,0 +1,58 @@
+// Wrap document.createElement and document.createElementNS to create a virtual document on iframes.
+const shimIFrameCreation = () => {
+  const createDocumentForIFrame = (el) => {
+    if (el.nodeName !== 'IFRAME' || !!el.document) {
+      return;
+    }
+
+    // Initialise a new virtual document for the frame.
+    const doc = new document.Document();
+    [
+      'createElement',
+      'createElementNS',
+      'createTextNode',
+      'Document',
+      'Node',
+      'Text',
+      'Element',
+      /* SVGElement: Element */,
+      'Event',
+    ].forEach((propName) => {
+      doc[propName] = document[propName];
+    });
+
+    // react-frame-component uses these methods to inject the initial
+    // conten into the frame's document, so we need to stub them.
+    doc.open = () => {};
+    doc.write = () => {}; // TODO: probably need to write into the real DOM so frame gets its initial content
+    doc.close = () => {};
+
+    // Wrapping this in a setTimeout allows the iframe creation to have been
+    // passed to the main thread before we start manipulating it. Otherwise,
+    // we have no way of associating the document with its frame in the main
+    // thread.
+    setTimeout(() => {
+      const docElement = doc.createElement('html');
+      doc.documentElement = docElement;
+      doc.appendChild(docElement);
+      docElement.appendChild(doc.head = doc.createElement('head'));
+      docElement.appendChild(doc.body = doc.createElement('body'));
+
+      el.document = el.contentDocument = doc;
+    });
+  };
+
+  [
+    'createElement',
+    'createElementNS',
+  ].forEach((methodName) => {
+    const origMethod = document[methodName];
+    document[methodName] = function(...args) {
+      const el = origMethod.apply(this, args);
+      createDocumentForIFrame(el);
+      return el;
+    };
+  });
+};
+
+export default shimIFrameCreation;

--- a/src/utils/dom/shimIFrameCreation.js
+++ b/src/utils/dom/shimIFrameCreation.js
@@ -38,31 +38,6 @@ const shimIFrameCreation = () => {
       };
     });
 
-    // react-frame-component uses these methods to inject the initial
-    // content into the frame's document, so we need to provide them.
-    doc.open = function() {};
-    doc.close = function() {};
-
-    doc.write = async function(content) {
-      return new Promise((resolve) => {
-        const onCompleted = ({ data }) => {
-          if (data.type !== 'documentWritten') {
-            return;
-          }
-
-          removeEventListener('message', onCompleted);
-          resolve();
-        };
-
-        addEventListener('message', onCompleted);
-        postMessage({
-          type: 'writeDocument',
-          content,
-          documentId: this._id,
-        });
-      });
-    };
-
     doc.ownerFrame = el;
 
     // Wrapping this in a setTimeout allows the iframe creation to have been

--- a/src/utils/dom/shimIFrameCreation.js
+++ b/src/utils/dom/shimIFrameCreation.js
@@ -21,6 +21,19 @@ const shimIFrameCreation = () => {
       doc[propName] = document[propName];
     });
 
+    [
+      'createElement',
+      'createElementNS',
+      'createTextNode',
+    ].forEach((methodName) => {
+      const origMethod = doc[methodName];
+      doc[methodName] = function(...args) {
+        const el = origMethod.apply(this, args);
+        el.ownerDocument = this;
+        return el;
+      };
+    });
+
     // react-frame-component uses these methods to inject the initial
     // conten into the frame's document, so we need to stub them.
     doc.open = () => {};

--- a/src/utils/workers/RenderWorker.js
+++ b/src/utils/workers/RenderWorker.js
@@ -5,11 +5,27 @@ export default class RenderWorker extends Worker {
   constructor(scriptUrl, { container, ...options }) {
     super(scriptUrl, options);
 
-    this._domMutationHandler = new DomMutationHandler({ container });
+    this._domMutationHandler = new DomMutationHandler({
+      container,
+      onNodeFirstSeen: (node) => this._initialiseNode(node),
+    });
 
     this._eventForwarder = new EventForwarder(window, (e) => this._forwardEvent(e));
 
     this.onmessage = this._handleMessage;
+  }
+
+  _initialiseNode(node) {
+    if (node.nodeName !== 'IFRAME') {
+      return;
+    }
+
+    // setTimeout is used here to give the frame's document a chance to be set.
+    setTimeout(() => {
+      [node, node.contentDocument].forEach((n) => {
+        n._eventForwarder = new EventForwarder(n, (e) => this._forwardEvent(e));
+      });
+    });
   }
 
   _handleMessage({ data }) {

--- a/src/utils/workers/RenderWorker.js
+++ b/src/utils/workers/RenderWorker.js
@@ -6,7 +6,8 @@ export default class RenderWorker extends Worker {
     super(scriptUrl, options);
 
     this._domMutationHandler = new DomMutationHandler({ container });
-    this._eventForwarder = new EventForwarder((e) => this._forwardEvent(e));
+
+    this._eventForwarder = new EventForwarder(window, (e) => this._forwardEvent(e));
 
     this.onmessage = this._handleMessage;
   }

--- a/src/workers/main.js
+++ b/src/workers/main.js
@@ -1,8 +1,14 @@
 import { render } from 'https://unpkg.com/preact@latest?module'
 import { html } from 'https://unpkg.com/htm/preact/index.module.js?module';
 import Counter from '../components/Counter.js';
+import WorkerSafeFrame from '../components/WorkerSafeFrame.js';
+
 import WorkerisedRenderer from '../utils/dom/WorkerisedRenderer.js';
 
 new WorkerisedRenderer(
-  () => render(html`<${Counter} />`, document.body)
+  () => render(html`
+    <${WorkerSafeFrame}>
+      <${Counter} />
+    </WorkerSafeFrame>
+  `, document.body)
 );

--- a/src/workers/main.js
+++ b/src/workers/main.js
@@ -2,7 +2,6 @@ import { render } from 'https://unpkg.com/preact@latest?module'
 import { html } from 'https://unpkg.com/htm/preact/index.module.js?module';
 import Counter from '../components/Counter.js';
 import WorkerSafeFrame from '../components/WorkerSafeFrame.js';
-
 import WorkerisedRenderer from '../utils/dom/WorkerisedRenderer.js';
 
 new WorkerisedRenderer(


### PR DESCRIPTION
This repo is currently being developed as a proof of concept for "workerifying" an existing Preact app in the interests of reducing its impact on page load. Everything that app renders is housed inside `iframe` elements that are rendered via the `Frame` component provided by the [`react-frame-component` package](https://github.com/ryanseddon/react-frame-component). As a result, this PR extends the app to work with the `Frame` component.

N.B. the `Frame` component and its internals are copied from the [`react-frame-component` source](https://github.com/ryanseddon/react-frame-component/blob/v4.1.3) because the component needs the `preact/compat` module in order to work in a Preact app, but I couldn't get that to load from a CDN. Also, loading `react-frame-component` from a CDN resulted in it pulling in a load of React dependencies which were at risk of interfering with Preact.

Demo – rendering the existing `Counter` component inside an iframe from a web worker:
![preact-in-web-worker-iframe-compat](https://github.com/andrewpye/preact-web-worker-demo/assets/5737342/dfe6a4a9-7f7a-4f16-bb01-844147ec79ea)
